### PR TITLE
Try patch: "Fix typo in libicu detection"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,9 @@ install:
   - docker pull ${DOCKER_IMAGE}
   - git clone --recursive --branch ${PYSIDE_BRANCH} https://code.qt.io/pyside/pyside-setup.git
 
+  # https://codereview.qt-project.org/#/c/219648/
+  - if [ "$PYSIDE_BRANCH" == "5.6" ]; then cd pyside-setup && git fetch https://codereview.qt-project.org/pyside/pyside-setup refs/changes/48/219648/1 && git checkout FETCH_HEAD & cd .. ; fi
+
 
 before_script:
   # Show which commit is being used

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ install:
   - git clone --recursive --branch ${PYSIDE_BRANCH} https://code.qt.io/pyside/pyside-setup.git
 
   # https://codereview.qt-project.org/#/c/219648/
-  - if [ "$PYSIDE_BRANCH" == "5.6" ]; then cd pyside-setup && git fetch https://codereview.qt-project.org/pyside/pyside-setup refs/changes/48/219648/1 && git checkout FETCH_HEAD & cd .. ; fi
+  - if [ "$PYSIDE_BRANCH" == "5.6" ]; then cd pyside-setup && git fetch https://codereview.qt-project.org/pyside/pyside-setup refs/changes/48/219648/1 && git checkout FETCH_HEAD && cd .. ; fi
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,10 +132,12 @@ script:
 
 after_success:
   - ls -alh
+  - ls -alh pyside-setup/dist
 
 
 after_failure:
   - ls -alh
+  - ls -alh pyside-setup/dist
 
 
 # before_deploy:


### PR DESCRIPTION
Scheduled build job failed in 5.6 branch. Patch was issued:
https://codereview.qt-project.org/#/c/219648/

Note: this patch will not get merged, only tested.